### PR TITLE
Adds streaming results and stack-frame info

### DIFF
--- a/api.md
+++ b/api.md
@@ -8,6 +8,7 @@
 , [testament/is](#testamentis)
 , [testament/reset-tests!](#testamentreset-tests)
 , [testament/run-tests!](#testamentrun-tests)
+, [testament/set-on-result-hook](#testamentset-on-result-hook)
 , [testament/set-report-printer](#testamentset-report-printer)
 
 ## testament/assert-equal
@@ -28,7 +29,7 @@ An optional `note` can be included that will be used in any failure report to
 identify the assertion. If no `note` is provided, the form `(= expect actual)`
 is used.
 
-[1]: src/testament.janet#L203
+[1]: src/testament.janet#L259
 
 ## testament/assert-expr
 
@@ -42,10 +43,10 @@ Assert that the expression, `expr`, is true (with an optional `note`)
 
 The `assert-expr` macro provides a mechanism for creating a generic assertion.
 
-An optional `note` can be included that will be used in any failure report to
+An optional `note` can be included that will be used in any failure result to
 identify the assertion. If no `note` is provided, the form of `expr` is used.
 
-[2]: src/testament.janet#L190
+[2]: src/testament.janet#L246
 
 ## testament/assert-thrown
 
@@ -64,7 +65,7 @@ An optional `note` can be included that will be used in any failure report to
 identify the assertion. If no `note` is provided, the form `thrown? expr` is
 used.
 
-[3]: src/testament.janet#L219
+[3]: src/testament.janet#L275
 
 ## testament/assert-thrown-message
 
@@ -84,7 +85,7 @@ An optional `note` can be included that will be used in any failure report to
 identify the assertion. If no `note` is provided, the form
 `thrown? expect expr` is used.
 
-[4]: src/testament.janet#L235
+[4]: src/testament.janet#L291
 
 ## testament/deftest
 
@@ -100,7 +101,7 @@ A test is just a function. The `body` is used as the body of the function
 produced by this macro but with respective setup and teardown steps inserted
 before and after the forms in `body` are called.
 
-[5]: src/testament.janet#L301
+[5]: src/testament.janet#L360
 
 ## testament/is
 
@@ -128,7 +129,10 @@ asserted expression.
 An optional `note` can be included that will be used in any failure report to
 identify the assertion.
 
-[6]: src/testament.janet#L255
+See the documentation for each assertion type for details of the result
+reported.
+
+[6]: src/testament.janet#L311
 
 ## testament/reset-tests!
 
@@ -140,33 +144,65 @@ identify the assertion.
 
 Reset all reporting variables
 
-[7]: src/testament.janet#L335
+[7]: src/testament.janet#L399
 
 ## testament/run-tests!
 
 **function**  | [source][8]
 
 ```janet
-(run-tests! &keys {:silent silent})
+(run-tests! &keys {:exit-on-fail exit? :silent silent?})
 ```
 
 Run the registered tests
 
-Accepts an optional `:silent` argument that will omit any reports being
-printed.
+This function will run the tests registered in the test suite via `deftest`.
+It accepts two optional arguments:
 
-[8]: src/testament.janet#L318
+1. `:silent` whether to omit the printing of reports (default: `false`); and
+2. `:exit-on-fail` whether to exit if any of the tests fail (default: `true`).
+
+[8]: src/testament.janet#L377
+
+## testament/set-on-result-hook
+
+**function**  | [source][9]
+
+```janet
+(set-on-result-hook f)
+```
+
+Set the `on-result-hook`
+
+The function `f` will be invoked when a `result` becomes available. The
+`result` is a struct with the following keys:
+
+- `:kind` the kind of assertion (as keyword);
+- `:passed?` whether an assertion succeeded (as boolean);
+- `:expect` the expected value of the assertion;
+- `:actual` the actual value of the assertion; and
+- `:note` a description of the assertion (as string).
+
+The 'value' of the assertion depends on the kind of assertion:
+
+- `:expr` either `true` or `false`;
+- `:equal` the value specified in the assertion;
+- `:thrown` either `true` or `false`; and
+- `:thrown-message` the error specified in the assertion.
+
+[9]: src/testament.janet#L25
 
 ## testament/set-report-printer
 
-**function**  | [source][9]
+**function**  | [source][10]
 
 ```janet
 (set-report-printer f)
 ```
 
-Sets the `print-reports` function. The function `f` will be applied with the
-following three arguments:
+Set the `print-reports` function
+
+The function `f` will be applied with the following three arguments:
 
 1. the number of tests run (as integer);
 2. number of assertions (as integer); and
@@ -175,5 +211,5 @@ following three arguments:
 The function will not be called if `run-tests!` is called with `:silent` set
 to `true`.
 
-[9]: src/testament.janet#L24
+[10]: src/testament.janet#L51
 

--- a/api.md
+++ b/api.md
@@ -29,7 +29,7 @@ An optional `note` can be included that will be used in any failure report to
 identify the assertion. If no `note` is provided, the form `(= expect actual)`
 is used.
 
-[1]: src/testament.janet#L259
+[1]: src/testament.janet#L262
 
 ## testament/assert-expr
 
@@ -46,7 +46,7 @@ The `assert-expr` macro provides a mechanism for creating a generic assertion.
 An optional `note` can be included that will be used in any failure result to
 identify the assertion. If no `note` is provided, the form of `expr` is used.
 
-[2]: src/testament.janet#L246
+[2]: src/testament.janet#L249
 
 ## testament/assert-thrown
 
@@ -65,7 +65,7 @@ An optional `note` can be included that will be used in any failure report to
 identify the assertion. If no `note` is provided, the form `thrown? expr` is
 used.
 
-[3]: src/testament.janet#L275
+[3]: src/testament.janet#L278
 
 ## testament/assert-thrown-message
 
@@ -85,7 +85,7 @@ An optional `note` can be included that will be used in any failure report to
 identify the assertion. If no `note` is provided, the form
 `thrown? expect expr` is used.
 
-[4]: src/testament.janet#L291
+[4]: src/testament.janet#L294
 
 ## testament/deftest
 
@@ -129,10 +129,7 @@ asserted expression.
 An optional `note` can be included that will be used in any failure report to
 identify the assertion.
 
-See the documentation for each assertion type for details of the result
-reported.
-
-[6]: src/testament.janet#L311
+[6]: src/testament.janet#L314
 
 ## testament/reset-tests!
 
@@ -174,8 +171,9 @@ It accepts two optional arguments:
 
 Set the `on-result-hook`
 
-The function `f` will be invoked when a `result` becomes available. The
-`result` is a struct with the following keys:
+The function `f` will be invoked when a result becomes available. The
+function is called with a single argument, the `result`. The `result` is a
+struct with the following keys:
 
 - `:kind` the kind of assertion (as keyword);
 - `:passed?` whether an assertion succeeded (as boolean);
@@ -190,7 +188,7 @@ The 'value' of the assertion depends on the kind of assertion:
 - `:thrown` either `true` or `false`; and
 - `:thrown-message` the error specified in the assertion.
 
-[9]: src/testament.janet#L25
+[9]: src/testament.janet#L90
 
 ## testament/set-report-printer
 
@@ -211,5 +209,5 @@ The function `f` will be applied with the following three arguments:
 The function will not be called if `run-tests!` is called with `:silent` set
 to `true`.
 
-[10]: src/testament.janet#L51
+[10]: src/testament.janet#L25
 

--- a/api.md
+++ b/api.md
@@ -25,7 +25,7 @@ The `assert-equal` macro provides a mechanism for creating an assertion that
 an expected result is equal to the actual result. The forms of `expect` and
 `actual` will be used in the output of any failure report.
 
-An optional `note` can be included that will be used in any failure report to
+An optional `note` can be included that will be used in any failure result to
 identify the assertion. If no `note` is provided, the form `(= expect actual)`
 is used.
 
@@ -61,7 +61,7 @@ Assert that an expression, `expr`, throws an error (with an optional `note`)
 The `assert-thrown` macro provides a mechanism for creating an assertion that
 an expression throws an error.
 
-An optional `note` can be included that will be used in any failure report to
+An optional `note` can be included that will be used in any failure result to
 identify the assertion. If no `note` is provided, the form `thrown? expr` is
 used.
 
@@ -81,7 +81,7 @@ Assert that the expression, `expr`, throws an error with the message `expect`
 The `assert-thrown` macro provides a mechanism for creating an assertion that
 an expression throws an error with the specified message.
 
-An optional `note` can be included that will be used in any failure report to
+An optional `note` can be included that will be used in any failure result to
 identify the assertion. If no `note` is provided, the form
 `thrown? expect expr` is used.
 
@@ -126,7 +126,7 @@ Testament includes support for four types of assertions:
 `is` causes the appropriate assertion to be inserted based on the form of the
 asserted expression.
 
-An optional `note` can be included that will be used in any failure report to
+An optional `note` can be included that will be used in any failure result to
 identify the assertion.
 
 [6]: src/testament.janet#L314

--- a/src/testament.janet
+++ b/src/testament.janet
@@ -22,32 +22,6 @@
 
 ### Reporting functions
 
-(defn set-on-result-hook
-  ```
-  Set the `on-result-hook`
-
-  The function `f` will be invoked when a `result` becomes available. The
-  `result` is a struct with the following keys:
-
-  - `:kind` the kind of assertion (as keyword);
-  - `:passed?` whether an assertion succeeded (as boolean);
-  - `:expect` the expected value of the assertion;
-  - `:actual` the actual value of the assertion; and
-  - `:note` a description of the assertion (as string).
-
-  The 'value' of the assertion depends on the kind of assertion:
-
-  - `:expr` either `true` or `false`;
-  - `:equal` the value specified in the assertion;
-  - `:thrown` either `true` or `false`; and
-  - `:thrown-message` the error specified in the assertion.
-  ```
-  [f]
-  (if (= :function (type f))
-    (set on-result-hook f)
-    (error "argument not of type :function")))
-
-
 (defn set-report-printer
   ```
   Set the `print-reports` function
@@ -109,6 +83,35 @@
     (print (string/repeat "-" len))
     (print stats)
     (print (string/repeat "-" len))))
+
+
+### Recording functions
+
+(defn set-on-result-hook
+  ```
+  Set the `on-result-hook`
+
+  The function `f` will be invoked when a result becomes available. The
+  function is called with a single argument, the `result`. The `result` is a
+  struct with the following keys:
+
+  - `:kind` the kind of assertion (as keyword);
+  - `:passed?` whether an assertion succeeded (as boolean);
+  - `:expect` the expected value of the assertion;
+  - `:actual` the actual value of the assertion; and
+  - `:note` a description of the assertion (as string).
+
+  The 'value' of the assertion depends on the kind of assertion:
+
+  - `:expr` either `true` or `false`;
+  - `:equal` the value specified in the assertion;
+  - `:thrown` either `true` or `false`; and
+  - `:thrown-message` the error specified in the assertion.
+  ```
+  [f]
+  (if (= :function (type f))
+    (set on-result-hook f)
+    (error "argument not of type :function")))
 
 
 (defn- add-to-report
@@ -327,9 +330,6 @@
 
   An optional `note` can be included that will be used in any failure report to
   identify the assertion.
-
-  See the documentation for each assertion type for details of the result
-  reported.
   ```
   [assertion &opt note]
   (case (which assertion)

--- a/src/testament.janet
+++ b/src/testament.janet
@@ -30,7 +30,7 @@
   `result` is a struct with the following keys:
 
   - `:kind` the kind of assertion (as keyword);
-  - `:passed?` whether an assertion succeeded (as Boolean);
+  - `:passed?` whether an assertion succeeded (as boolean);
   - `:expect` the expected value of the assertion;
   - `:actual` the actual value of the assertion; and
   - `:note` a description of the assertion (as string).

--- a/src/testament.janet
+++ b/src/testament.janet
@@ -371,20 +371,20 @@
   ```
   Run the registered tests
 
-  Accepts an optional `:silent` argument that will omit any reports being
-  printed.
+  This function will run the tests registered in the test suite via `deftest`.
+  It accepts two optional arguments:
 
-  Accepts an optional `:do-exit` argument tells run-tests! whether to exit
-  or not when all tests have run. Default is `true`.
+  1. `:silent` whether to omit the printing of reports (default: `false`); and
+  2. `:exit-on-fail` whether to exit if any of the tests fail (default: `true`).
   ```
-  [&keys {:silent silent :do-exit do-exit}]
-  (default do-exit true)
+  [&keys {:silent silent? :exit-on-fail exit?}]
+  (default exit? true)
   (each test tests (test))
-  (unless silent
+  (unless silent?
     (when (nil? print-reports)
       (set-report-printer default-print-reports))
     (print-reports num-tests-run num-asserts num-tests-passed))
-  (when do-exit
+  (when exit?
     (unless  (= num-tests-run num-tests-passed)
       (os/exit 1))))
 

--- a/src/testament.janet
+++ b/src/testament.janet
@@ -219,9 +219,9 @@
   identify the assertion. If no `note` is provided, the form of `expr` is used.
 
   When an assertion is run as part of a test, the result is saved in the test's
-  report. The result of an assertion is a struct with 3 keys: (1) `:passed?` (a
-  boolean), (2) `:details` (a string) and (3) `:note` (a string). If the
-  assertion succeeds, the value of `:details` will be "Passed". If the
+  report. The result of an assertion is a struct with three keys: (1)
+  `:passed?` (a boolean), (2) `:details` (a string) and (3) `:note` (a string).
+  If the assertion succeeds, the value of `:details` will be "Passed". If the
   assertion fails, the value of `:details` will be "Reason: Result is Boolean
   false".
   ```
@@ -242,11 +242,11 @@
   is used.
 
   When an assertion is run as part of a test, the result is saved in the test's
-  report. The result of an assertion is a struct with 3 keys: (1) `:passed?` (a
-  boolean), (2) `:details` (a string) and (3) `:note` (a string). If the
-  assertion succeeds, the value of `:details` will be "Passed". If the
-  assertion fails, the value of `:details` will be "Expect:
-  <expected evaluation>\nActual: <actual evaluation>".
+  report. The result of an assertion is a struct with three keys: (1)
+  `:passed?` (a boolean), (2) `:details` (a string) and (3) `:note` (a string).
+  If the assertion succeeds, the value of `:details` will be "Passed". If the
+  assertion fails, the value of `:details` will be "Expect: <expected
+  evaluation>\nActual: <actual evaluation>".
   ```
   [expect actual &opt note]
   ~(,assert-equal* ,expect ',expect ,actual ',actual ,note))
@@ -264,9 +264,9 @@
   used.
 
   When an assertion is run as part of a test, the result is saved in the test's
-  report. The result of an assertion is a struct with 3 keys: (1) `:passed?` (a
-  boolean), (2) `:details` (a string) and (3) `:note` (a string). If the
-  assertion succeeds, the value of `:details` will be "Passed". If the
+  report. The result of an assertion is a struct with three keys: (1)
+  `:passed?` (a boolean), (2) `:details` (a string) and (3) `:note` (a string).
+  If the assertion succeeds, the value of `:details` will be "Passed". If the
   assertion fails, the value of `:details` will be "Reason: No error thrown".
   ```
   [expr &opt note]
@@ -287,9 +287,9 @@
   `thrown? expect expr` is used.
 
   When an assertion is run as part of a test, the result is saved in the test's
-  report. The result of an assertion is a struct with 3 keys: (1) `:passed?` (a
-  boolean), (2) `:details` (a string) and (3) `:note` (a string). If the
-  assertion succeeds, the value of `:details` will be "Passed". If the
+  report. The result of an assertion is a struct with three keys: (1)
+  `:passed?` (a boolean), (2) `:details` (a string) and (3) `:note` (a string).
+  If the assertion succeeds, the value of `:details` will be "Passed". If the
   assertion fails, the value of `:details` will be "Expect: Error message
   <expected message>\nActual: Error message <actual message>".
   ```

--- a/src/testament.janet
+++ b/src/testament.janet
@@ -267,7 +267,7 @@
   an expected result is equal to the actual result. The forms of `expect` and
   `actual` will be used in the output of any failure report.
 
-  An optional `note` can be included that will be used in any failure report to
+  An optional `note` can be included that will be used in any failure result to
   identify the assertion. If no `note` is provided, the form `(= expect actual)`
   is used.
   ```
@@ -282,7 +282,7 @@
   The `assert-thrown` macro provides a mechanism for creating an assertion that
   an expression throws an error.
 
-  An optional `note` can be included that will be used in any failure report to
+  An optional `note` can be included that will be used in any failure result to
   identify the assertion. If no `note` is provided, the form `thrown? expr` is
   used.
   ```
@@ -299,7 +299,7 @@
   The `assert-thrown` macro provides a mechanism for creating an assertion that
   an expression throws an error with the specified message.
 
-  An optional `note` can be included that will be used in any failure report to
+  An optional `note` can be included that will be used in any failure result to
   identify the assertion. If no `note` is provided, the form
   `thrown? expect expr` is used.
   ```
@@ -328,7 +328,7 @@
   `is` causes the appropriate assertion to be inserted based on the form of the
   asserted expression.
 
-  An optional `note` can be included that will be used in any failure report to
+  An optional `note` can be included that will be used in any failure result to
   identify the assertion.
   ```
   [assertion &opt note]

--- a/test/testament.janet
+++ b/test/testament.janet
@@ -13,7 +13,11 @@
 
 (defn test-assert-expr-macro []
   (let [summary (t/assert-expr 1)]
-    (unless (= {:passed? true :note "1" :details "Passed"} summary)
+    (unless (= summary {:kind    :expr
+                        :passed? true
+                        :expect  true
+                        :actual  true
+                        :note    "1"})
       (error "Test failed"))))
 
 
@@ -22,7 +26,11 @@
 
 (defn test-assert-equal-macro []
   (let [summary (t/assert-equal 1 1)]
-    (unless (= {:passed? true :note "(= 1 1)" :details "Passed"} summary)
+    (unless (= summary {:kind    :equal
+                        :passed? true
+                        :expect  1
+                        :actual  1
+                        :note    "(= 1 1)"})
       (error "Test failed"))))
 
 
@@ -31,7 +39,11 @@
 
 (defn test-assert-thrown-macro []
   (let [summary (t/assert-thrown (error "An error"))]
-    (unless (= {:passed? true :note "thrown? (error \"An error\")" :details "Passed"} summary)
+    (unless (= summary {:kind    :thrown
+                        :passed? true
+                        :expect  true
+                        :actual  true
+                        :note    "thrown? (error \"An error\")"})
       (error "Test failed"))))
 
 
@@ -40,7 +52,11 @@
 
 (defn test-assert-thrown-message-macro []
   (let [summary (t/assert-thrown-message "An error" (error "An error"))]
-    (unless (= {:passed? true :note "thrown? \"An error\" (error \"An error\")" :details "Passed"} summary)
+    (unless (= summary {:kind    :thrown-message
+                        :passed? true
+                        :expect  "An error"
+                        :actual  "An error"
+                        :note    "thrown? \"An error\" (error \"An error\")"})
       (error "Test failed"))))
 
 
@@ -49,7 +65,11 @@
 
 (defn test-is-macro-with-value []
   (let (summary (t/is 1))
-    (unless (= {:passed? true :note "1" :details "Passed"} summary)
+    (unless (= summary {:kind    :expr
+                        :passed? true
+                        :expect  true
+                        :actual  true
+                        :note    "1"})
       (error "Test failed"))))
 
 
@@ -58,7 +78,11 @@
 
 (defn test-is-macro-with-equality []
   (let (summary (t/is (= 1 2)))
-    (unless (= {:passed? false :note "(= 1 2)" :details "Expect: 1\nActual: 2"} summary)
+    (unless (= summary {:kind    :equal
+                        :passed? false
+                        :expect  1
+                        :actual  2
+                        :note    "(= 1 2)"})
       (error "Test failed"))))
 
 
@@ -67,7 +91,11 @@
 
 (defn test-is-macro-with-thrown []
   (let [summary (t/is (thrown? (error "An error")))]
-    (unless (= {:passed? true :note "thrown? (error \"An error\")" :details "Passed"} summary)
+    (unless (= summary {:kind    :thrown
+                        :passed? true
+                        :expect  true
+                        :actual  true
+                        :note    "thrown? (error \"An error\")"})
       (error "Test failed"))))
 
 
@@ -76,7 +104,11 @@
 
 (defn test-is-macro-with-thrown-message []
   (let [summary (t/is (thrown? "An error" (error "An error")))]
-    (unless (= {:passed? true :note "thrown? \"An error\" (error \"An error\")" :details "Passed"} summary)
+    (unless (= summary {:kind    :thrown-message
+                        :passed? true
+                        :expect  "An error"
+                        :actual  "An error"
+                        :note    "thrown? \"An error\" (error \"An error\")"})
       (error "Test failed"))))
 
 
@@ -121,7 +153,11 @@
 (defn test-on-result-hook []
   (var called false)
   (t/set-on-result-hook (fn [summary]
-                          (unless (= {:passed? true :note "1" :details "Passed"} summary)
+                          (unless (= summary {:kind    :equal
+                                              :passed? true
+                                              :expect  1
+                                              :actual  1
+                                              :note   "1"})
                             (error "Test failed"))
                           (set called true)))
   (t/deftest test-name (t/assert-equal 1 1 "1"))

--- a/test/testament.janet
+++ b/test/testament.janet
@@ -113,6 +113,28 @@
       (error "Test failed"))))
 
 
+(test-custom-reporting)
+
+
+(t/reset-tests!)
+
+(defn test-on-result-hook []
+  (var called false)
+  (t/set-on-result-hook (fn [summary]
+                          (unless (= {:passed? true :note "1" :report "Passed"} summary)
+                            (error "Test failed"))
+                          (set called true)))
+  (t/deftest test-name (t/assert-equal 1 1 "1"))
+  (let [output @""]
+    (with-dyns [:out output]
+      (t/run-tests!))
+    (unless called
+      (error "Test failed. on-result-hook was not called."))))
+
+
+(test-on-result-hook)
+
+
 (t/reset-tests!)
 
 (defn test-reporting-silent []

--- a/test/testament.janet
+++ b/test/testament.janet
@@ -13,7 +13,7 @@
 
 (defn test-assert-expr-macro []
   (let [summary (t/assert-expr 1)]
-    (unless (= {:passed? true :note "1" :report "Passed"} summary)
+    (unless (= {:passed? true :note "1" :details "Passed"} summary)
       (error "Test failed"))))
 
 
@@ -22,7 +22,7 @@
 
 (defn test-assert-equal-macro []
   (let [summary (t/assert-equal 1 1)]
-    (unless (= {:passed? true :note "(= 1 1)" :report "Passed"} summary)
+    (unless (= {:passed? true :note "(= 1 1)" :details "Passed"} summary)
       (error "Test failed"))))
 
 
@@ -31,7 +31,7 @@
 
 (defn test-assert-thrown-macro []
   (let [summary (t/assert-thrown (error "An error"))]
-    (unless (= {:passed? true :note "thrown? (error \"An error\")" :report "Passed"} summary)
+    (unless (= {:passed? true :note "thrown? (error \"An error\")" :details "Passed"} summary)
       (error "Test failed"))))
 
 
@@ -40,7 +40,7 @@
 
 (defn test-assert-thrown-message-macro []
   (let [summary (t/assert-thrown-message "An error" (error "An error"))]
-    (unless (= {:passed? true :note "thrown? \"An error\" (error \"An error\")" :report "Passed"} summary)
+    (unless (= {:passed? true :note "thrown? \"An error\" (error \"An error\")" :details "Passed"} summary)
       (error "Test failed"))))
 
 
@@ -49,7 +49,7 @@
 
 (defn test-is-macro-with-value []
   (let (summary (t/is 1))
-    (unless (= {:passed? true :note "1" :report "Passed"} summary)
+    (unless (= {:passed? true :note "1" :details "Passed"} summary)
       (error "Test failed"))))
 
 
@@ -58,7 +58,7 @@
 
 (defn test-is-macro-with-equality []
   (let (summary (t/is (= 1 2)))
-    (unless (= {:passed? false :note "(= 1 2)" :report "Expect: 1\nActual: 2"} summary)
+    (unless (= {:passed? false :note "(= 1 2)" :details "Expect: 1\nActual: 2"} summary)
       (error "Test failed"))))
 
 
@@ -67,7 +67,7 @@
 
 (defn test-is-macro-with-thrown []
   (let [summary (t/is (thrown? (error "An error")))]
-    (unless (= {:passed? true :note "thrown? (error \"An error\")" :report "Passed"} summary)
+    (unless (= {:passed? true :note "thrown? (error \"An error\")" :details "Passed"} summary)
       (error "Test failed"))))
 
 
@@ -76,7 +76,7 @@
 
 (defn test-is-macro-with-thrown-message []
   (let [summary (t/is (thrown? "An error" (error "An error")))]
-    (unless (= {:passed? true :note "thrown? \"An error\" (error \"An error\")" :report "Passed"} summary)
+    (unless (= {:passed? true :note "thrown? \"An error\" (error \"An error\")" :details "Passed"} summary)
       (error "Test failed"))))
 
 
@@ -121,7 +121,7 @@
 (defn test-on-result-hook []
   (var called false)
   (t/set-on-result-hook (fn [summary]
-                          (unless (= {:passed? true :note "1" :report "Passed"} summary)
+                          (unless (= {:passed? true :note "1" :details "Passed"} summary)
                             (error "Test failed"))
                           (set called true)))
   (t/deftest test-name (t/assert-equal 1 1 "1"))


### PR DESCRIPTION
This is a work in progress, but I'm opening the PR so we can discuss. There are a couple of code comments, marked `WIP:` (shoulda called it RFC) about the changes, which I'll remove if and when this PR becomes mergeable.

The main points here are:

- The streaming of results. There's a `on-result-hook` that can be set, and will be invoked when results become available. Example usage is in the TAP style emitter found in `test/`. I've tested using the output from that to feed into a couple of existing pretty-printers with acceptable results.

- Extraction of stack frame data using `(debug/stack (fiber/current))`. This one is a bit finicky, and need more testing, because, as-is, it just assumes that the relevant stack frame is at index `2`, which probably is not always the case.