### PR TITLE
Remove extra delimiter in two-plus-two test

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Testament can be used like this:
   (is (= 2 (+ 1 1)) "1 + 1 = 2"))
 
 (deftest two-plus-two
-  (is (= 5 (+ 2 2)) "2 + 2 = 5")))
+  (is (= 5 (+ 2 2)) "2 + 2 = 5"))
 
 (run-tests!)
 ```


### PR DESCRIPTION
Hi I blindly copy/pasted this to test out the library myself and discovered an extra delimiter.

Thought I would fix it while it was still fresh on my mind.