### PR TITLE
Add defsuite!

### DIFF
--- a/api.md
+++ b/api.md
@@ -2,7 +2,7 @@
 
 ## testament
 
-[==](#), [assert-deep-equal](#assert-deep-equal), [assert-equal](#assert-equal), [assert-equivalent](#assert-equivalent), [assert-expr](#assert-expr), [assert-thrown](#assert-thrown), [assert-thrown-message](#assert-thrown-message), [deftest](#deftest), [is](#is), [reset-tests!](#reset-tests), [run-tests!](#run-tests), [set-on-result-hook](#set-on-result-hook), [set-report-printer](#set-report-printer)
+[==](#), [assert-deep-equal](#assert-deep-equal), [assert-equal](#assert-equal), [assert-equivalent](#assert-equivalent), [assert-expr](#assert-expr), [assert-matches](#assert-matches), [assert-thrown](#assert-thrown), [assert-thrown-message](#assert-thrown-message), [deftest](#deftest), [exercise!](#exercise), [is](#is), [reset-tests!](#reset-tests), [run-tests!](#run-tests), [set-on-result-hook](#set-on-result-hook), [set-report-printer](#set-report-printer)
 
 ## ==
 
@@ -42,7 +42,7 @@ An optional `note` can be included that will be used in any failure result to
 identify the assertion. If no `note` is provided, the form
 `(deep= expect actual)` is used.
 
-[2]: src/testament.janet#L371
+[2]: src/testament.janet#L392
 
 ## assert-equal
 
@@ -62,7 +62,7 @@ An optional `note` can be included that will be used in any failure result to
 identify the assertion. If no `note` is provided, the form `(= expect actual)`
 is used.
 
-[3]: src/testament.janet#L355
+[3]: src/testament.janet#L376
 
 ## assert-equivalent
 
@@ -85,7 +85,7 @@ An optional `note` can be included that will be used in any failure result to
 identify the assertion. If no `note` is provided, the form `(== expect actual)`
 is used.
 
-[4]: src/testament.janet#L387
+[4]: src/testament.janet#L408
 
 ## assert-expr
 
@@ -102,11 +102,30 @@ The `assert-expr` macro provides a mechanism for creating a generic assertion.
 An optional `note` can be included that will be used in any failure result to
 identify the assertion. If no `note` is provided, the form of `expr` is used.
 
-[5]: src/testament.janet#L342
+[5]: src/testament.janet#L363
+
+## assert-matches
+
+**macro**  | [source][6]
+
+```janet
+(assert-matches structure actual &opt note)
+```
+
+Assert that `structure` matches `actual` (with an optional `note`)
+
+The `assert-matches` macro provides a mechanism for creating an assertion that
+an expression matches a particular structure (at least in part).
+
+An optional `note` can be included that will be used in any failure result to
+identify the assertion. If no `note` is provided, the form
+`(matches structure actual)` is used.
+
+[6]: src/testament.janet#L427
 
 ## assert-thrown
 
-**macro**  | [source][6]
+**macro**  | [source][7]
 
 ```janet
 (assert-thrown expr &opt note)
@@ -121,11 +140,11 @@ An optional `note` can be included that will be used in any failure result to
 identify the assertion. If no `note` is provided, the form `thrown? expr` is
 used.
 
-[6]: src/testament.janet#L406
+[7]: src/testament.janet#L442
 
 ## assert-thrown-message
 
-**macro**  | [source][7]
+**macro**  | [source][8]
 
 ```janet
 (assert-thrown-message expect expr &opt note)
@@ -141,11 +160,11 @@ An optional `note` can be included that will be used in any failure result to
 identify the assertion. If no `note` is provided, the form
 `thrown? expect expr` is used.
 
-[7]: src/testament.janet#L422
+[8]: src/testament.janet#L458
 
 ## deftest
 
-**macro**  | [source][8]
+**macro**  | [source][9]
 
 ```janet
 (deftest & args)
@@ -173,11 +192,33 @@ guaranteed.
 If `deftest` is called with no arguments or if the only argument is a symbol,
 an arity error is raised.
 
-[8]: src/testament.janet#L499
+[9]: src/testament.janet#L541
+
+## exercise!
+
+**macro**  | [source][10]
+
+```janet
+(exercise! args & body)
+```
+
+Define, run and reset the tests provided in the macro body
+
+This macro will run the forms in `body`, call `run-test!`, call `reset-tests!`
+and then return the value of `run-tests!`.
+
+The user can specify the arguments to be passed to `run-tests!` by providing a
+tuple as `args`. If no arguments are necessary, `args` should be an empty
+tuple.
+
+Please note that, like `run-tests!`, `exercise!` calls `os/exit` when there
+are failing tests unless the argument `:exit-on-fail` is set to `false`.
+
+[10]: src/testament.janet#L620
 
 ## is
 
-**macro**  | [source][9]
+**macro**  | [source][11]
 
 ```janet
 (is assertion &opt note)
@@ -186,7 +227,7 @@ an arity error is raised.
 Assert that an `assertion` is true (with an optional `note`)
 
 The `is` macro provides a succinct mechanism for creating assertions.
-Testament includes support for six types of assertions:
+Testament includes support for seven types of assertions:
 
 1. a generic assertion that asserts the Boolean truth of an expression;
 2. an equality assertion that asserts that an expected result and an actual
@@ -195,8 +236,10 @@ Testament includes support for six types of assertions:
    actual result are deeply equal;
 4. an equivalence assertion that asserts that an expected result and an actual
    result are equivalent;
-5. a throwing assertion that asserts an error is thrown; and
-6. a throwing assertion that asserts an error with a specific message is
+5. a matches assertion that asserts that an expected result matches a
+   particular structure (at least in part);
+6. a throwing assertion that asserts an error is thrown; and
+7. a throwing assertion that asserts an error with a specific message is
    thrown.
 
 `is` causes the appropriate assertion to be inserted based on the form of the
@@ -205,11 +248,11 @@ asserted expression.
 An optional `note` can be included that will be used in any failure result to
 identify the assertion.
 
-[9]: src/testament.janet#L442
+[11]: src/testament.janet#L478
 
 ## reset-tests!
 
-**function**  | [source][10]
+**function**  | [source][12]
 
 ```janet
 (reset-tests!)
@@ -217,11 +260,11 @@ identify the assertion.
 
 Reset all reporting variables
 
-[10]: src/testament.janet#L559
+[12]: src/testament.janet#L605
 
 ## run-tests!
 
-**function**  | [source][11]
+**function**  | [source][13]
 
 ```janet
 (run-tests! &keys {:exit-on-fail exit? :silent silent?})
@@ -235,11 +278,14 @@ It accepts two optional arguments:
 1. `:silent` whether to omit the printing of reports (default: `false`); and
 2. `:exit-on-fail` whether to exit if any of the tests fail (default: `true`).
 
-[11]: src/testament.janet#L537
+Please note that `run-tests!` calls `os/exit` when there are failing tests
+unless the argument `:exit-on-fail` is set to `false`.
+
+[13]: src/testament.janet#L580
 
 ## set-on-result-hook
 
-**function**  | [source][12]
+**function**  | [source][14]
 
 ```janet
 (set-on-result-hook f)
@@ -266,11 +312,11 @@ The 'value' of the assertion depends on the kind of assertion:
 - `:thrown` either `true` or `false`; and
 - `:thrown-message` the error specified in the assertion.
 
-[12]: src/testament.janet#L140
+[14]: src/testament.janet#L144
 
 ## set-report-printer
 
-**function**  | [source][13]
+**function**  | [source][15]
 
 ```janet
 (set-report-printer f)
@@ -287,5 +333,5 @@ The function `f` will be applied with the following three arguments:
 The function will not be called if `run-tests!` is called with `:silent` set
 to `true`.
 
-[13]: src/testament.janet#L75
+[15]: src/testament.janet#L75
 

--- a/src/testament.janet
+++ b/src/testament.janet
@@ -576,6 +576,7 @@
 
 ### Test suite functions
 
+
 (defn run-tests!
   ```
   Run the registered tests
@@ -611,3 +612,11 @@
   (set reports @{})
   (set print-reports nil)
   (set on-result-hook (fn [&])))
+
+(defmacro defsuite! [& body]
+  ```
+  Automatically runs the tests defined in the macro body
+  ```
+  ~(do
+     ,;body
+     (,(comptime run-tests!))))

--- a/src/testament.janet
+++ b/src/testament.janet
@@ -603,13 +603,14 @@
   ```
   Automatically run the tests defined in the macro body
 
-  The macro can optionally be provided with a bracketed tuple containing
-  arguments to be passed to `run-tests!`.
+  If `first-form` is a bracketed tuple, the items in the tuple are treated as
+  arguments to `run-tests!` and the form is discarded. Otherwise, the form is
+  evaluated.
   ```
-  [head & tail]
-  (let [has-args? (and (tuple? head) (= :brackets (tuple/type head)))
-        args      (if has-args? head [])
-        forms     (if has-args? tail [head ;tail])]
+  [first-form & other-forms]
+  (let [has-args? (and (tuple? first-form) (= :brackets (tuple/type first-form)))
+        args      (if has-args? first-form [])
+        forms     (if has-args? other-forms [first-form ;other-forms])]
     ~(do
        ,;forms
        (,run-tests! ,;args))))

--- a/src/testament.janet
+++ b/src/testament.janet
@@ -599,6 +599,22 @@
       (os/exit 1))))
 
 
+(defmacro do-tests
+  ```
+  Automatically run the tests defined in the macro body
+
+  The macro can optionally be provided with a bracketed tuple containing
+  arguments to be passed to `run-tests!`.
+  ```
+  [head & tail]
+  (let [has-args? (and (tuple? head) (= :brackets (tuple/type head)))
+        args      (if has-args? head [])
+        forms     (if has-args? tail [head ;tail])]
+    ~(do
+       ,;forms
+       (,run-tests! ,;args))))
+
+
 (defn reset-tests!
   ```
   Reset all reporting variables
@@ -612,11 +628,3 @@
   (set reports @{})
   (set print-reports nil)
   (set on-result-hook (fn [&])))
-
-(defmacro defsuite! [& body]
-  ```
-  Automatically runs the tests defined in the macro body
-  ```
-  ~(do
-     ,;body
-     (,(comptime run-tests!))))

--- a/test/testament.janet
+++ b/test/testament.janet
@@ -278,5 +278,22 @@
     (unless (empty? (string output))
       (error "Test failed"))))
 
-
 (test-reporting-silent)
+
+(defn test-defsuite! []
+  (var called false)
+  (t/set-on-result-hook (fn [summary]
+                          (unless (= summary {:test    'test-name
+                                              :kind    :equal
+                                              :passed? true
+                                              :expect  1
+                                              :actual  1
+                                              :note   "1"})
+                            (error "Test failed"))
+                          (set called true)))
+  (let [output @""]
+    (with-dyns [:out output]
+      (t/defsuite!
+        (t/deftest test-name (t/assert-equal 1 1 "1"))))
+    (unless called
+      (error "Test failed. on-result-hook was not called."))))

--- a/test/testament.janet
+++ b/test/testament.janet
@@ -263,28 +263,28 @@
 
 (t/reset-tests!)
 
-(defn test-do-tests []
+(defn test-exercise! []
   (let [output @""
         stats  "1 tests run containing 1 assertions\n1 tests passed, 0 tests failed"
         len    (->> (string/split "\n" stats) (map length) splice max)
         rule   (string/repeat "-" len)]
     (with-dyns [:out output]
-      (t/do-tests
+      (t/exercise! []
         (t/deftest test-name (t/assert-equal 1 1))))
     (unless (= (string "\n" rule "\n" stats "\n" rule "\n") (string output))
       (error "Test failed"))))
 
-(test-do-tests)
+(test-exercise!)
 
 
 (t/reset-tests!)
 
-(defn test-do-tests-silent []
+(defn test-exercise!-silent []
   (let [output @""]
     (with-dyns [:out output]
-      (t/do-tests [:silent true]
+      (t/exercise! [:silent true]
         (t/deftest test-name (t/assert-equal 1 1))))
     (unless (empty? (string output))
       (error "Test failed"))))
 
-(test-do-tests)
+(test-exercise!-silent)

--- a/test/testament.janet
+++ b/test/testament.janet
@@ -7,7 +7,6 @@
   (unless (t/== x y)
     (error "Test failed")))
 
-
 (test-==)
 
 
@@ -16,7 +15,6 @@
   (unless (= :function (type test-name))
     (error "Test failed")))
 
-
 (test-deftest-macro)
 
 
@@ -24,7 +22,6 @@
   (def anon-test (t/deftest :noop))
   (unless (= :function (type anon-test))
     (error "Test failed")))
-
 
 (test-anon-deftest-macro)
 
@@ -38,7 +35,6 @@
                         :note    "1"})
       (error "Test failed"))))
 
-
 (test-assert-expr-macro)
 
 
@@ -50,7 +46,6 @@
                         :actual  1
                         :note    "(= 1 1)"})
       (error "Test failed"))))
-
 
 (test-assert-equal-macro)
 
@@ -64,7 +59,6 @@
                             :note    "(deep= @[1] @[1])"})
       (error "Test failed"))))
 
-
 (test-assert-deep-equal-macro)
 
 
@@ -76,7 +70,6 @@
                             :actual  @[1]
                             :note    "(== [1] @[1])"})
       (error "Test failed"))))
-
 
 (test-assert-equivalent-macro)
 
@@ -90,7 +83,6 @@
                             :note    "(matches {:a _} {:a 10})"})
      (error "Test failed"))))
 
-
 (test-assert-matches-macro)
 
 
@@ -102,7 +94,6 @@
                         :actual  true
                         :note    "thrown? (error \"An error\")"})
       (error "Test failed"))))
-
 
 (test-assert-thrown-macro)
 
@@ -116,7 +107,6 @@
                         :note    "thrown? \"An error\" (error \"An error\")"})
       (error "Test failed"))))
 
-
 (test-assert-thrown-message-macro)
 
 
@@ -128,7 +118,6 @@
                         :actual  true
                         :note    "1"})
       (error "Test failed"))))
-
 
 (test-is-macro-with-value)
 
@@ -142,7 +131,6 @@
                         :note    "(= 1 2)"})
       (error "Test failed"))))
 
-
 (test-is-macro-with-equality)
 
 
@@ -154,7 +142,6 @@
                             :actual  @[2]
                             :note    "(deep= @[1] @[2])"})
       (error "Test failed"))))
-
 
 (test-is-macro-with-deep-equality)
 
@@ -168,7 +155,6 @@
                             :note    "(== [1] @[2])"})
       (error "Test failed"))))
 
-
 (test-is-macro-with-equivalence)
 
 
@@ -180,7 +166,6 @@
                             :actual  {:a 10}
                             :note    "(matches {:b _} {:a 10})"})
      (error "Test failed"))))
-
 
 (test-is-macro-with-matches)
 
@@ -194,7 +179,6 @@
                         :note    "thrown? (error \"An error\")"})
       (error "Test failed"))))
 
-
 (test-is-macro-with-thrown)
 
 
@@ -206,7 +190,6 @@
                         :actual  "An error"
                         :note    "thrown? \"An error\" (error \"An error\")"})
       (error "Test failed"))))
-
 
 (test-is-macro-with-thrown-message)
 
@@ -224,7 +207,6 @@
     (unless (= (string "\n" rule "\n" stats "\n" rule "\n") (string output))
       (error "Test failed"))))
 
-
 (test-reporting)
 
 
@@ -239,7 +221,6 @@
       (t/run-tests!))
     (unless (= (string "CUSTOM:1:1:1:" "\n") (string output))
       (error "Test failed"))))
-
 
 (test-custom-reporting)
 
@@ -264,7 +245,6 @@
     (unless called
       (error "Test failed. on-result-hook was not called."))))
 
-
 (test-on-result-hook)
 
 
@@ -280,20 +260,31 @@
 
 (test-reporting-silent)
 
-(defn test-defsuite! []
-  (var called false)
-  (t/set-on-result-hook (fn [summary]
-                          (unless (= summary {:test    'test-name
-                                              :kind    :equal
-                                              :passed? true
-                                              :expect  1
-                                              :actual  1
-                                              :note   "1"})
-                            (error "Test failed"))
-                          (set called true)))
+
+(t/reset-tests!)
+
+(defn test-do-tests []
+  (let [output @""
+        stats  "1 tests run containing 1 assertions\n1 tests passed, 0 tests failed"
+        len    (->> (string/split "\n" stats) (map length) splice max)
+        rule   (string/repeat "-" len)]
+    (with-dyns [:out output]
+      (t/do-tests
+        (t/deftest test-name (t/assert-equal 1 1))))
+    (unless (= (string "\n" rule "\n" stats "\n" rule "\n") (string output))
+      (error "Test failed"))))
+
+(test-do-tests)
+
+
+(t/reset-tests!)
+
+(defn test-do-tests-silent []
   (let [output @""]
     (with-dyns [:out output]
-      (t/defsuite!
-        (t/deftest test-name (t/assert-equal 1 1 "1"))))
-    (unless called
-      (error "Test failed. on-result-hook was not called."))))
+      (t/do-tests [:silent true]
+        (t/deftest test-name (t/assert-equal 1 1))))
+    (unless (empty? (string output))
+      (error "Test failed"))))
+
+(test-do-tests)


### PR DESCRIPTION
`defsuite` is a macro that automatically calls `run-tests!` after 
executing the body passed to it. It is intended to make (run-tests!) 
harder to forget, as I've forgotten it twice already. I prefer having something
I write up front (in the pattern of defer), rather than something I have
to remember at the end.