### PR TITLE
Allow redefining tests with a dyn flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,13 @@ Actual: 4
 
 By default, Testament prevents defining two tests with the same name. If you're repeatedly evaluating a test file in REPL, this will cause your re-evaluated `deftest` to fail.
 
-Set the dynamic variable `:testament-allow-redefining-tests` to `true` to disable this check, e.g. with:
+Set the dynamic variable `*testament-repl-mode*` to `true` to disable this check, e.g. with:
 ```
-(setdyn :testament-allow-redefining-tests true)
+(setdyn *testament-repl-mode* true)
 ```
 
-You'll also want to pass `:exit-on-fail false` to `run-tests!`, otherwise Testament will quit your REPL if a test fails.
-```
-(run-tests! :exit-on-fail false)
-```
+This will also stop Testament from exiting your REPL if a test fails.
+
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -58,16 +58,16 @@ Actual (R): 4
 
 ### In REPLs
 
-To use Tetament in a REPL set the dynamic variable `:testament-repl?` to
+To use Testament in a REPL, set the dynamic variable `:testament-repl?` to
 `true`:
 
 ```
 (setdyn :testament-repl? true)
 ```
 
-This will (a) stop Testament from the your REPL if a test fails, (b) reset the
-reports between runs and (c) empty the `module/cache` to prevent old code from
-running.
+This will (a) stop Testament from exiting your REPL if a test fails, (b) reset
+the reports between runs and (c) empty the `module/cache` to prevent old code
+from running.
 
 
 ## API

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Actual: 4
 
 By default, Testament prevents defining two tests with the same name. If you're repeatedly evaluating a test file in REPL, this will cause your re-evaluated `deftest` to fail.
 
-Set the dynamic variable `*testament-repl-mode*` to `true` to disable this check, e.g. with:
+Set the dynamic variable `:testament-repl-mode` to `true` to disable this check, e.g. with:
 ```
-(setdyn *testament-repl-mode* true)
+(setdyn :testament-repl-mode true)
 ```
 
 This will also stop Testament from exiting your REPL if a test fails.

--- a/README.md
+++ b/README.md
@@ -58,14 +58,20 @@ Actual: 4
 
 ### Note for REPL users
 
-By default, Testament prevents defining two tests with the same name. If you're repeatedly evaluating a test file in REPL, this will cause your re-evaluated `deftest` to fail.
+By default, Testament prevents defining two tests with the same name. If you're
+repeatedly evaluating a test file in REPL, this will cause your re-evaluated
+`deftest` to fail.
 
-Set the dynamic variable `:testament-repl-mode` to `true` to disable this check, e.g. with:
+Set the dynamic variable `:testament-repl-mode` to `true` to disable this
+check, e.g. with:
+
 ```
 (setdyn :testament-repl-mode true)
 ```
 
-This will also stop Testament from exiting your REPL if a test fails, reset the reports between runs, and empty the `module/cache` to prevent old code from running.
+This will also stop Testament from exiting your REPL if a test fails, reset the
+reports between runs, and empty the `module/cache` to prevent old code from
+running.
 
 
 ## API

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ Actual: 4
 -----------------------------------
 ```
 
+Note for REPL users:
+By default, Testament prevents defining two tests with the same name. If you're repeatedly evaluating a test file in REPL, this will cause your re-evaluated `deftest` to fail.
+
+Set the dynamic variable `:testament-allow-redefining-tests` to `true` to disable this check, e.g. with:
+```
+(setdyn :testament-allow-redefining-tests true)
+```
+
 ## API
 
 Documentation for Testament's API is in [api.md][api].

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ running test/example.janet ...
 
 > Failed: two-plus-two
 Assertion: 2 + 2 = 5
-Expect: 5
-Actual: 4
+Expect (L): 5
+Actual (R): 4
 
 -----------------------------------
 2 tests run containing 2 assertions
@@ -56,21 +56,17 @@ Actual: 4
 -----------------------------------
 ```
 
-### Note for REPL users
+### In REPLs
 
-By default, Testament prevents defining two tests with the same name. If you're
-repeatedly evaluating a test file in REPL, this will cause your re-evaluated
-`deftest` to fail.
-
-Set the dynamic variable `:testament-repl-mode` to `true` to disable this
-check, e.g. with:
+To use Tetament in a REPL set the dynamic variable `:testament-repl?` to
+`true`:
 
 ```
-(setdyn :testament-repl-mode true)
+(setdyn :testament-repl? true)
 ```
 
-This will also stop Testament from exiting your REPL if a test fails, reset the
-reports between runs, and empty the `module/cache` to prevent old code from
+This will (a) stop Testament from the your REPL if a test fails, (b) reset the
+reports between runs and (c) empty the `module/cache` to prevent old code from
 running.
 
 

--- a/README.md
+++ b/README.md
@@ -56,12 +56,18 @@ Actual: 4
 -----------------------------------
 ```
 
-Note for REPL users:
+### Note for REPL users
+
 By default, Testament prevents defining two tests with the same name. If you're repeatedly evaluating a test file in REPL, this will cause your re-evaluated `deftest` to fail.
 
 Set the dynamic variable `:testament-allow-redefining-tests` to `true` to disable this check, e.g. with:
 ```
 (setdyn :testament-allow-redefining-tests true)
+```
+
+You'll also want to pass `:exit-on-fail false` to `run-tests!`, otherwise Testament will quit your REPL if a test fails.
+```
+(run-tests! :exit-on-fail false)
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Set the dynamic variable `:testament-repl-mode` to `true` to disable this check,
 (setdyn :testament-repl-mode true)
 ```
 
-This will also stop Testament from exiting your REPL if a test fails.
+This will also stop Testament from exiting your REPL if a test fails, reset the reports between runs, and empty the `module/cache` to prevent old code from running.
 
 
 ## API

--- a/api.md
+++ b/api.md
@@ -214,7 +214,7 @@ tuple.
 Please note that, like `run-tests!`, `exercise!` calls `os/exit` when there
 are failing tests unless the argument `:exit-on-fail` is set to `false`.
 
-[10]: src/testament.janet#L628
+[10]: src/testament.janet#L649
 
 ## is
 
@@ -260,7 +260,7 @@ identify the assertion.
 
 Reset all reporting variables
 
-[12]: src/testament.janet#L613
+[12]: src/testament.janet#L588
 
 ## run-tests!
 
@@ -279,7 +279,8 @@ It accepts two optional arguments:
 2. `:exit-on-fail` whether to exit if any of the tests fail (default: `true`).
 
 Please note that `run-tests!` calls `os/exit` when there are failing tests
-unless the argument `:exit-on-fail` is set to `false`.
+unless the argument `:exit-on-fail` is set to `false` or the
+`:testament-repl?` dynamic variable is set to `true`.
 
 In all other cases, the function returns an indexed collection of test
 reports. Each report in the collection is a dictionary collection containing
@@ -288,7 +289,11 @@ test while `:passes` and `:failures` contain the results of each respective
 passed and failed assertion. Each result is a data structure of the kind
 described in the docstring for `set-on-result-hook`.
 
-[13]: src/testament.janet#L581
+When the dynamic variable `:testament-repl?` is set to `true`, this will
+also reset the test reports and empty the module/cache to provide a fresh run
+with the most up-to-date code.
+
+[13]: src/testament.janet#L603
 
 ## set-on-result-hook
 

--- a/src/testament.janet
+++ b/src/testament.janet
@@ -201,10 +201,10 @@
 
   This function will raise an error if a test with the same `name` has already
   been registered in the test suite, unless the dynamic variable
-  *testament-repl-mode* has been set to true.
+  :testament-repl-mode has been set to true.
   ```
   [name t]
-  (unless (or (nil? (tests name)) (true? (dyn *testament-repl-mode*)))
+  (unless (or (nil? (tests name)) (true? (dyn :testament-repl-mode)))
     (error "cannot register tests with the same name"))
   (set (tests name) t))
 
@@ -606,7 +606,7 @@
     (when (nil? print-reports)
       (set-report-printer default-print-reports))
     (print-reports num-tests-run num-asserts num-tests-passed))
-  (if (and exit? (not (= num-tests-run num-tests-passed)) (not (true? (dyn *testament-repl-mode*))))
+  (if (and exit? (not (= num-tests-run num-tests-passed)) (not (true? (dyn :testament-repl-mode))))
     (os/exit 1)
     (values reports)))
 

--- a/src/testament.janet
+++ b/src/testament.janet
@@ -576,6 +576,15 @@
 
 
 ### Test suite functions
+
+(defn- empty-module-cache! []
+  ```
+  Empty module/cache to prevent caching between test runs in the same process
+  ```
+  (each key (keys module/cache)
+    (put module/cache key nil)))
+
+
 (defn reset-tests!
   ```
   Reset all reporting variables
@@ -591,14 +600,6 @@
   (set on-result-hook (fn [&])))
 
 
-(defn empty-module-cache! []
-  ```
-  Empties module/cache to prevent caching between test runs in the same process
-  ```
-  (each key (keys module/cache)
-    (put module/cache key nil)))
-
-
 (defn run-tests!
   ```
   Run the registered tests
@@ -611,7 +612,7 @@
 
   Please note that `run-tests!` calls `os/exit` when there are failing tests
   unless the argument `:exit-on-fail` is set to `false` or the
-  `:testament-repl-mode` dynamic variable is set to `true`.
+  `:testament-repl?` dynamic variable is set to `true`.
 
   In all other cases, the function returns an indexed collection of test
   reports. Each report in the collection is a dictionary collection containing
@@ -620,7 +621,7 @@
   passed and failed assertion. Each result is a data structure of the kind
   described in the docstring for `set-on-result-hook`.
 
-  When the dynamic variable `:testament-repl-mode` is set to `true`, this will
+  When the dynamic variable `:testament-repl?` is set to `true`, this will
   also reset the test reports and empty the module/cache to provide a fresh run
   with the most up-to-date code.
   ```
@@ -632,14 +633,14 @@
       (set-report-printer default-print-reports))
     (print-reports num-tests-run num-asserts num-tests-passed))
 
-  (def repl-mode? (true? (dyn :testament-repl-mode)))
+  (def in-repl? (dyn :testament-repl?))
   (def report-values (values reports))
 
-  (if (and exit?
-           (not (= num-tests-run num-tests-passed))
-           (not repl-mode?))
+  (when (and exit?
+             (not (= num-tests-run num-tests-passed))
+             (not in-repl?))
     (os/exit 1))
-  (when repl-mode?
+  (when in-repl?
     (reset-tests!)
     (empty-module-cache!))
   report-values)

--- a/src/testament.janet
+++ b/src/testament.janet
@@ -200,7 +200,8 @@
   Register a test `t` with a `name `in the test suite
 
   This function will raise an error if a test with the same `name` has already
-  been registered in the test suite.
+  been registered in the test suite, unless the dynamic variable
+  :testament-allow-redefining-tests has been set to true.
   ```
   [name t]
   (unless (or (nil? (tests name)) (true? (dyn :testament-allow-redefining-tests)))

--- a/src/testament.janet
+++ b/src/testament.janet
@@ -627,13 +627,17 @@
     (when (nil? print-reports)
       (set-report-printer default-print-reports))
     (print-reports num-tests-run num-asserts num-tests-passed))
-  (if (and exit? (not (= num-tests-run num-tests-passed)) (not (true? (dyn :testament-repl-mode))))
-    (os/exit 1)
-    (values reports))
-  (if (true? (dyn :testament-repl-mode))
+
+  (def repl-mode? (true? (dyn :testament-repl-mode)))
+  (def report-values (values reports))
+
+  (if (and exit? (not (= num-tests-run num-tests-passed)) (not repl-mode?))
+    (os/exit 1))
+  (if repl-mode?
     (do
       (reset-tests!)
-      (empty-module-cache!))))
+      (empty-module-cache!)))
+  report-values)
 
 (defmacro exercise!
   ```

--- a/src/testament.janet
+++ b/src/testament.janet
@@ -591,7 +591,7 @@
   (set print-reports nil)
   (set on-result-hook (fn [&])))
 
-(defn- empty-module-cache []
+(defn empty-module-cache! []
   "Empties module/cache to prevent caching between test runs in the same process"
   (each key (keys module/cache)
     (put module/cache key nil)))
@@ -631,8 +631,9 @@
     (os/exit 1)
     (values reports))
   (if (true? (dyn :testament-repl-mode))
-    (reset-tests!)
-    (empty-module-cache)))
+    (do
+      (reset-tests!)
+      (empty-module-cache!))))
 
 (defmacro exercise!
   ```

--- a/src/testament.janet
+++ b/src/testament.janet
@@ -201,10 +201,10 @@
 
   This function will raise an error if a test with the same `name` has already
   been registered in the test suite, unless the dynamic variable
-  :testament-allow-redefining-tests has been set to true.
+  *testament-repl-mode* has been set to true.
   ```
   [name t]
-  (unless (or (nil? (tests name)) (true? (dyn :testament-allow-redefining-tests)))
+  (unless (or (nil? (tests name)) (true? (dyn *testament-repl-mode*)))
     (error "cannot register tests with the same name"))
   (set (tests name) t))
 
@@ -606,7 +606,7 @@
     (when (nil? print-reports)
       (set-report-printer default-print-reports))
     (print-reports num-tests-run num-asserts num-tests-passed))
-  (if (and exit? (not (= num-tests-run num-tests-passed)))
+  (if (and exit? (not (= num-tests-run num-tests-passed)) (not (true? (dyn *testament-repl-mode*))))
     (os/exit 1)
     (values reports)))
 

--- a/src/testament.janet
+++ b/src/testament.janet
@@ -203,7 +203,7 @@
   been registered in the test suite.
   ```
   [name t]
-  (unless (nil? (tests name))
+  (unless (or (nil? (tests name)) (true? (dyn :testament-allow-redefining-tests)))
     (error "cannot register tests with the same name"))
   (set (tests name) t))
 

--- a/test/testament.janet
+++ b/test/testament.janet
@@ -17,26 +17,17 @@
 
 (test-deftest-macro)
 
+
 (defn test-deftest-same-name-macro []
   (t/deftest same-name :noop)
-  (try
-    (do
-      (t/deftest same-name :noop)
-      (error "Redefining a test with the same name should have failed"))
-    ([err fib]
-     (unless (= err "cannot register tests with the same name")
-       (propagate err fib)))))
+  (def err @"")
+  (with-dyns [:err err]
+    (t/deftest same-name :noop)
+    (unless (= (string err) "[testament] registered multiple tests with the same name\n")
+      (error "no warning"))))
 
 (test-deftest-same-name-macro)
 
-(defn test-deftest-same-name-allowed-macro []
-  (with-dyns [:testament-repl-mode true]
-    (t/deftest same-name-allowed :noop)
-    (t/deftest same-name-allowed :nop)
-    (unless (= :function (type same-name-allowed))
-      (error "Test failed"))))
-
-(test-deftest-same-name-allowed-macro)
 
 (defn test-anon-deftest-macro []
   (def anon-test (t/deftest :noop))

--- a/test/testament.janet
+++ b/test/testament.janet
@@ -17,6 +17,26 @@
 
 (test-deftest-macro)
 
+(defn test-deftest-same-name-macro []
+  (t/deftest same-name :noop)
+  (try
+    (do
+      (t/deftest same-name :noop)
+      (error "Redefining a test with the same name should have failed"))
+    ([err fib]
+     (unless (= err "cannot register tests with the same name")
+       (propagate err fib)))))
+
+(test-deftest-same-name-macro)
+
+(defn test-deftest-same-name-allowed-macro []
+  (with-dyns [:testament-allow-redefining-tests true]
+    (t/deftest same-name-allowed :noop)
+    (t/deftest same-name-allowed :nop)
+    (unless (= :function (type same-name-allowed))
+      (error "Test failed"))))
+
+(test-deftest-same-name-allowed-macro)
 
 (defn test-anon-deftest-macro []
   (def anon-test (t/deftest :noop))

--- a/test/testament.janet
+++ b/test/testament.janet
@@ -30,7 +30,7 @@
 (test-deftest-same-name-macro)
 
 (defn test-deftest-same-name-allowed-macro []
-  (with-dyns [:testament-allow-redefining-tests true]
+  (with-dyns [:testament-repl-mode true]
     (t/deftest same-name-allowed :noop)
     (t/deftest same-name-allowed :nop)
     (unless (= :function (type same-name-allowed))


### PR DESCRIPTION
This allows me to re-evaluate test files in the REPL without running into the same-name constraint.